### PR TITLE
Allow for custom function fields in email templates

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -79,6 +79,32 @@ class templateParser
                     }
                     $link = $secureLink;
                     $repl_arr[$key . "_" . $fieldName] = '<img src="' . $link . '" width="'.$field_def['width'].'" height="'.$field_def['height'].'"/>';
+                } else if ($field_def['source'] == 'function') {
+					$can_execute = true;
+					$execute_params = array();
+					$execute_function = array();
+					if (!empty($field_def['function_class'])) {
+						$execute_function[] = $field_def['function_class'];
+						$execute_function[] = $field_def['function_name'];
+					} else {
+						$execute_function = $field_def['function_name'];
+					}
+					foreach ($field_def['function_params'] as $param) {
+						if ($param == '$this') {
+							$execute_params[] = $focus;
+						} elseif (empty($focus->$param)) {
+							$can_execute = false;
+						} else {
+							$execute_params[] = $focus->$param;
+						}
+					}
+					if ($can_execute) {
+						if (!empty($field_def['function_require'])) {
+							require_once($field_def['function_require']);
+						}
+						$repl_arr[$key . "_" . $fieldName] = call_user_func_array($execute_function, $execute_params);
+					}
+
                 } else {
                     $repl_arr[$key . "_" . $fieldName] = $focus->$fieldName;
                 }


### PR DESCRIPTION
#### Issue
E-mails send by the Workflow module based on an Email template do not contain function fields (source = 'function' in vardef definition). Those fields are not automatically calculated, when the bean is initiated and the db row retrieved. For standard views the function fields are calculated during displaying. For email templates they however stayed blank.

#### Solution
Update the templateParser.php file within the AOS_PDF_Templates module in order to calculate function fields while creating the replacement array for the template markers.
The solution is similar to the calculation of those fields in /include/EditView/EditView2.php lines 1000 to 1040

## How To Test This
Create an email template including a function field from a vardef and try to send it automatically.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->